### PR TITLE
fix: ask signature instead of selector

### DIFF
--- a/src/scripts.ts
+++ b/src/scripts.ts
@@ -68,14 +68,14 @@ export const createSafeTx = async (provider: string) => {
       case TransactionType.callContract:
         to = await inputAddress({ message: prefix + `Contract address` });
 
-        const functionSelector = await input({
-          message: prefix + `Function selector`,
+        const functionSignature = await input({
+          message: prefix + `Function signature`,
           validate: trial(
             (value) => !!FunctionFragment.from(`function ${value}`),
-            "Invalid function selector"
+            "Invalid function signature"
           ),
         });
-        const fragment = FunctionFragment.from(`function ${functionSelector}`);
+        const fragment = FunctionFragment.from(`function ${functionSignature}`);
 
         const values = [];
         for (const { param, index } of fragment.inputs.map((param, index) => ({ param, index }))) {


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change
The prompt is now asking for the function signature instead of the function selector.
This change is needed as `FunctionFragment` from `ethers` is used.
Fix #21

Old behavior with dummy function
<img width="1113" alt="Capture d’écran 2023-08-18 à 11 25 00" src="https://github.com/morpho-labs/create-safe-tx/assets/92337658/16ff48a0-0ec5-44e4-88c4-d872f3963511">

New behavior
<img width="775" alt="Capture d’écran 2023-08-18 à 11 23 55" src="https://github.com/morpho-labs/create-safe-tx/assets/92337658/93f49199-7505-4589-85f2-f790d71d0367">

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `main` branch
- [] `npm run lint` passes with this change  N/A
- [] `npm run test` passes with this change N/A
- [X] This pull request links relevant issues as `Fixes #0000`
- [] There are new or updated unit tests validating the change N/A
- [] Documentation has been updated to reflect this change N/A
- [X] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
