### PR TITLE
fix(transferfunds): remove the second time the ERC20 amount was being decimal adjusted

### DIFF
--- a/src/scripts.ts
+++ b/src/scripts.ts
@@ -144,13 +144,10 @@ export const createSafeTx = async (provider: string) => {
         });
 
         to = await inputAddress({ message: prefix + `Recipient address` });
-        const amount = parseUnits(
-          await input({
-            message: prefix + `Amount`,
-            validate: trial((value) => !!parseUnits(value, decimals), "Invalid amount"),
-          }),
-          decimals
-        );
+        const amount = await input({
+          message: prefix + `Amount`,
+          validate: trial((value) => !!parseUnits(value, decimals), "Invalid amount"),
+        });
 
         txs.push(
           encodeSingle({ id: "", type: txType, to, token, amount: amount.toString(), decimals })


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change
When doing an ERC20 transfer, the amount decimal adjusted was being applied twice, once in this library and a second time within ethers-multisend. The adjustment in this package has been removed.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change (THERE NO LINT SCRIPT) 
- [x] `npm run test` passes with this change (THERE ARE NO TESTS)
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change (THERE ARE NO TESTS)
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
